### PR TITLE
Use server login rather than client-side check

### DIFF
--- a/src/ce/core/Controller.hx
+++ b/src/ce/core/Controller.hx
@@ -1063,22 +1063,10 @@ class Controller {
 						application.onServiceAuthorizationDone = function(? result : Null<OAuthResult>) {
 
 								application.setAuthPopupDisplayed(false);
-
-								if (state.serviceList.get(srv).isOAuth) {
-
-									if (result != null && result.notApproved != true) {
-
-										login(srv);
-
-									} else {
-
-										application.setLoaderDisplayed(false);
-									}
-
-								} else {
-
-									login(srv);
-								}
+								// Will ask Unifile if the client is logged
+								login(srv);
+								// Unbind to prevent the timer to call it a second time
+								application.onServiceAuthorizationDone = null;
 							}
 
 						var authUrl : String = cr.authorizeUrl + (cr.authorizeUrl.indexOf('?') > -1 ? '&' : '?')


### PR DESCRIPTION
Don't read the OAuth return querystring and systematically try to login.
The check is transfered to the server (Unifile). To avoid collision with
the popup closing timer, handler is unbound when logging in.

This will close #54.

What do you think @zabojad @lexoyo?